### PR TITLE
Fix system reset not persisting to server

### DIFF
--- a/muster-client/src/TablesFrame.js
+++ b/muster-client/src/TablesFrame.js
@@ -20,7 +20,7 @@ import {
   createTable,
   shuffleZero,
   requestResetSeats,
-  systemReset,
+  systemResetServer,
 } from "@grumbleware/event-muster-store";
 
 const drawerWidth = 240;
@@ -113,7 +113,7 @@ export default function ClippedDrawer() {
               button
               key="systemReset"
               onClick={() => {
-                dispatch(systemReset());
+                dispatch(systemResetServer());
               }}
             >
               <ListItemIcon>

--- a/muster-server/src/routes/api/index.js
+++ b/muster-server/src/routes/api/index.js
@@ -4,7 +4,7 @@ import { io } from "../../express-app";
 import playersRouter from "./players";
 import tablesRouter from "./tables";
 import seatsRouter from "./seats";
-import systemReset from "@grumbleware/event-muster-store";
+import { systemReset } from "@grumbleware/event-muster-store";
 const router = Router();
 
 router.use("/players", playersRouter);

--- a/muster-server/src/sequelize/index.js
+++ b/muster-server/src/sequelize/index.js
@@ -285,7 +285,8 @@ export const shuffleZero = async () => {
 };
 
 export const systemReset = async () => {
-  return await sequelize.drop();
+  await sequelize.drop();
+  return await sequelize.sync();
 };
 
 if (process.env.NODE_ENV != "production") {

--- a/muster-store/src/api-interface.js
+++ b/muster-store/src/api-interface.js
@@ -60,4 +60,9 @@ export const shuffleZero = async () => {
   return response.data;
 };
 
+export const resetSystem = async () => {
+  const response = await axios.post("api/systemReset");
+  return response;
+};
+
 export default axios;

--- a/muster-store/src/features/systemActions.js
+++ b/muster-store/src/features/systemActions.js
@@ -1,3 +1,11 @@
-import { createAction } from "@reduxjs/toolkit";
+import { createAction, createAsyncThunk } from "@reduxjs/toolkit";
 
 export const systemReset = createAction("systemReset");
+
+export const systemResetServer = createAsyncThunk(
+  "systemResetServer",
+  async (_, { extra: api }) => {
+    const responseFromServer = await api.resetSystem();
+    return;
+  }
+);


### PR DESCRIPTION
Creates a missing thunk to call the system reset REST endpoing on the server.
Previously, the client was dispatching the local system reset event directly, so it would not reach the server.

Fix #42